### PR TITLE
paho-mqtt: redirect SRC_URI to github tree

### DIFF
--- a/recipes-connectivity/paho-mqtt/paho-mqtt_3.1.bb
+++ b/recipes-connectivity/paho-mqtt/paho-mqtt_3.1.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = " \
 
 PR = "r1"
 
-SRC_URI = "git://git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.c.git;protocol=http \
+SRC_URI = "git://github.com/eclipse/paho.mqtt.c.git;protocol=https \
            file://makefile.patch \
 "
 


### PR DESCRIPTION
As git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.c is nomore
available, use a github mirror.

Signed-off-by: Franck Demathieu franck.demathieu@intel.com
