### PR TITLE
Mraa and upm fixes

### DIFF
--- a/recipes-devtools/mraa/mraa.inc
+++ b/recipes-devtools/mraa/mraa.inc
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git"
 
 inherit distutils-base pkgconfig python-dir cmake
 
-EXTRA_OECMAKE_append = "-DINSTALLTOOLS=ON -DFIRMATA=ON -DINSTALLGPIOTOOL=ON -DPYTHON_SITE_DIR:FILEPATH=${PYTHON_SITEPACKAGES_DIR} -DBASE_LIB_INSTALL_DIR=${base_libdir} -DCMAKE_SKIP_RPATH=ON"
+EXTRA_OECMAKE_append = "-DINSTALLTOOLS=ON -DFIRMATA=ON -DPYTHON_SITE_DIR:FILEPATH=${PYTHON_SITEPACKAGES_DIR} -DBASE_LIB_INSTALL_DIR=${base_libdir} -DCMAKE_SKIP_RPATH=ON"
 
 FILES_${PN}-doc += "${datadir}/mraa/examples/"
 
@@ -25,6 +25,7 @@ PACKAGECONFIG ??= "${@bb.utils.contains('PACKAGES', 'node-${PN}', 'nodejs', '', 
 PACKAGECONFIG[python] = "-DBUILDSWIGPYTHON=ON, -DBUILDSWIGPYTHON=OFF, swig-native python,"
 PACKAGECONFIG[nodejs] = "-DBUILDSWIGNODE=ON, -DBUILDSWIGNODE=OFF, swig-native nodejs,"
 PACKAGECONFIG[java] = "-DBUILDSWIGJAVA=ON, -DBUILDSWIGJAVA=OFF, swig-native openjdk-8-native,"
+PACKAGECONFIG[ft4222] = "-DUSBPLAT=ON -DFTDI4222=ON, -DUSBPLAT=OFF -DFTDI4222=OFF,, libft4222"
 
 do_compile_prepend () {
   # when yocto builds in ${D} it does not have access to ../git/.git so git

--- a/recipes-devtools/upm/upm_0.7.2.bb
+++ b/recipes-devtools/upm/upm_0.7.2.bb
@@ -5,7 +5,7 @@ AUTHOR = "Brendan Le Foll, Tom Ingleby, Yevgeniy Kiveisha"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d1cc191275d6a8c5ce039c75b2b3dc29"
 
-DEPENDS = "nodejs libjpeg-turbo swig-native mraa"
+DEPENDS = "libjpeg-turbo mraa"
 
 SRC_URI = "git://github.com/intel-iot-devkit/upm.git;protocol=git;tag=v${PV}"
 


### PR DESCRIPTION
mraa: Added ft4222 PACKAGECONFIG entry and cleaned up cmake tools install
upm: Remove nodejs and swig-native from DEPENDS, will be handled by PACKAGECONFIG (see issue #6)
