### PR TITLE
[mraa][upm] node always looks in /usr/lib

### DIFF
--- a/recipes-devtools/mraa/mraa.inc
+++ b/recipes-devtools/mraa/mraa.inc
@@ -56,7 +56,7 @@ INSANE_SKIP_python-${PN} = "debug-files"
 ### Node ###
 
 # node-mraa package containing Nodejs bindings
-FILES_node-${PN} = "${libdir}/node_modules/ \
+FILES_node-${PN} = "${prefix}/lib/node_modules/ \
                     ${datadir}/mraa/examples/javascript/ \
                    "
 RDEPENDS_node-${PN} += "nodejs"

--- a/recipes-devtools/upm/upm_0.7.2.bb
+++ b/recipes-devtools/upm/upm_0.7.2.bb
@@ -50,7 +50,7 @@ INSANE_SKIP_${PYTHON_PN}-${PN} = "debug-files"
 ### Node ###
 
 # node-upm package containing Nodejs bindings
-FILES_node-${PN} = "${libdir}/node_modules/ \
+FILES_node-${PN} = "${prefix}/lib/node_modules/ \
                     ${datadir}/${BPN}/examples/javascript/ \
                    "
 RDEPENDS_node-${PN} += "nodejs mraa"


### PR DESCRIPTION
Addresses issue #14 .  Nodejs is configured to look for modules in /usr/lib.  On multilib systems, ${libdir} may not be /usr/lib which breaks mraa and upm.
